### PR TITLE
Add initialisation and box installation step to vm setup docs

### DIFF
--- a/vm.md
+++ b/vm.md
@@ -24,6 +24,10 @@ title: Seldon VM
 
         wget http://static.seldon.io/seldonvm/Vagrantfile
 
+1. Initialise the directory and install an Ubuntu box.
+
+        vagrant init hashicorp/precise64
+
 1. Startup the vagrant instance of the box.
 
         vagrant up


### PR DESCRIPTION
Without this step I get the following error:

```
Bringing machine 'default' up with 'virtualbox' provider...
==> default: Box 'base' could not be found. Attempting to find and install...
    default: Box Provider: virtualbox
    default: Box Version: >= 0
==> default: Box file was not detected as metadata. Adding it directly...
==> default: Adding box 'base' (v0) for provider: virtualbox
    default: Downloading: base
An error occurred while downloading the remote file. The error
message, if any, is reproduced below. Please fix this error and try
again.

Couldn't open file seldonvm/base
```
