### PR TITLE
Added instructions to work with memory constrained laptops

### DIFF
--- a/install.md
+++ b/install.md
@@ -118,11 +118,15 @@ Check you have enough memory. At least 6G is needed to run everything locally on
 
 In addition, the following may help:
 
-1. Reduce the memory allocation for ***mysql*** and ***seldon-server*** pods before running [seldon-up](scripts.html#seldon-up) using the following commands. The default is 3GB for the ***mysql*** and ***seldon-server*** pods. This command specified 2GB each for ***mysql*** and ***seldon-server*** pods. In general, you can try different values: for example, if you just need to run the Reuters and Iris examples, even 1 GB for ***mysql*** will work.
+1. Reduce the memory allocation for ***mysql*** and ***seldon-server*** pods before running [seldon-up](scripts.html#seldon-up) using the following commands:
+
 {% highlight bash %}
  cd kubernetes/conf
  make clean conf MYSQL_RESOURCES='"requests":{ "memory" : "2Gi" }' SELDON_SERVER_RESOURCES='"requests":{ "memory" : "2Gi" }'
 {% endhighlight %}
+
+This command reduces the memory allocation for the ***mysql*** and ***seldon-server*** pods from the default 3GB each to 2GB each. If you just need to run the Reuters recommendation and Iris prediction examples, even 1 GB for ***mysql*** will work.
+
 2. Disable Spark, in case you do not intend to use it. To do so, invoke [seldon-up](scripts.html#seldon-up) like this:
 {% highlight bash %}
 SELDON_WITH_SPARK=false seldon-up

--- a/install.md
+++ b/install.md
@@ -116,6 +116,17 @@ ADMISSION_CONTROL=NamespaceLifecycle,LimitRanger,SecurityContextDeny,ServiceAcco
 
 Check you have enough memory. At least 6G is needed to run everything locally on a single node. If you are using minikube then you can start a minikube kubernetes with 6G of memory with ```minikube start --memory=6000```
 
+In addition, the following may help:
+
+1. Reduce the memory allocation for ***mysql*** and ***seldon-server*** pods before running [seldon-up](scripts.html#seldon-up) using the following commands. The default is 3GB for the ***mysql*** and ***seldon-server*** pods. This command specified 2GB each for ***mysql*** and ***seldon-server*** pods. In general, you can try different values: for example, if you just need to run the Reuters and Iris examples, even 1 GB for ***mysql*** will work.
+{% highlight bash %}
+ cd kubernetes/conf
+ make clean conf MYSQL_RESOURCES='"requests":{ "memory" : "2Gi" }' SELDON_SERVER_RESOURCES='"requests":{ "memory" : "2Gi" }'
+{% endhighlight %}
+2. Disable Spark, in case you do not intend to use it. To do so, invoke [seldon-up](scripts.html#seldon-up) like this:
+{% highlight bash %}
+SELDON_WITH_SPARK=false seldon-up
+{% endhighlight %}
 
 If you are using a Vagrant VM to run your kubernetes cluster ensure it has 6G of memory available from the host machine.
 


### PR DESCRIPTION
Even with 8 GB on my laptop and by using the "minikube start --memory=6000" command, seldon-server wouldn't startup on my machine, with the memory usage touching 7.5 GB and nothing else running on my MacBook Pro running Yosemite 10.10.5. I found that seldon-server remained in the Pending state.

Reducing the memory requirements on mysql and seldon-server pods help me progress and execute the Reuters recommendation and the Iris prediction example.

A note about bash highlighting: the syntax for bash highlighting used in the install.md file doesn't render on my machine. So I wasn't able to verify how the page looks. I did try the syntax that uses backticks and it worked. However, I removed the backticks and reverted back to the syntax that appears in the document for consistency. I am hoping what I added does indeed show up well.

As an aside, it might be useful to put in a check in the seldon-up script to check if the seldon-server pod is running before exiting. It is a useful check for situations such as the one I described in the first paragraph. I would be happy to submit a pull request for that one.